### PR TITLE
refactor: 이미지 로드시 화면 보여주도록

### DIFF
--- a/src/pages/question.tsx
+++ b/src/pages/question.tsx
@@ -35,6 +35,16 @@ export default function question() {
   const MAX_PAGE = 12;
   const setUserRecommendation = useSetRecoilState(UserRecommendation);
 
+  const [loading, setLoading] = useState(false);
+
+  const setImageLoadingComplete = (e: any) => {
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    setLoading(true);
+  }, [currentPage]);
+
   useEffect(() => {
     if (data !== undefined) {
       setQuestionData(data?.data);
@@ -62,6 +72,26 @@ export default function question() {
     ]);
     setCurrentPage(currentPage + 1);
   };
+
+  if (loading)
+    return (
+      <div>
+        <Image
+          onLoadingComplete={(e) => setImageLoadingComplete(e)}
+          loading="eager"
+          priority
+          className="mb-[2rem] rounded-[1.25rem]  px-4"
+          alt="image that explain Question"
+          width={450}
+          height={450}
+          src={
+            questionData?.data.test.questions[currentPage - 1]
+              .imageUrl as string
+          }
+        />
+        <div>로딩중</div>
+      </div>
+    );
 
   return (
     isSuccess && (


### PR DESCRIPTION
## 작업 내용
-화면 로딩상태 구현
## 참고 이미지(선택)
![화면 기록 2023-03-08 오후 2 08 29](https://user-images.githubusercontent.com/103626175/223625499-f6428add-e191-4fa5-9ca0-1e6be54a1b01.gif)


## 어떤 점을 리뷰 받고 싶으신가요?
실제로 만든 로딩 넣어야됨
